### PR TITLE
docs: note Symphony fork under test

### DIFF
--- a/docs/07-SYMPHONY.md
+++ b/docs/07-SYMPHONY.md
@@ -1,6 +1,7 @@
 # Symphony
 
 This repository is prepared for the prototype Symphony runner from `openai/symphony`.
+This workflow is currently tested against the `clauBv23` fork.
 
 ## Files
 


### PR DESCRIPTION
## Summary
- Add a note that the Symphony workflow is currently tested against the `clauBv23` fork.

## Validation
- `pnpm prettier --check docs/07-SYMPHONY.md`